### PR TITLE
Check if the popover is hidden before sending the shown event

### DIFF
--- a/kuma/static/js/contribution-handler.js
+++ b/kuma/static/js/contribution-handler.js
@@ -504,7 +504,7 @@
     setupTooltips();
 
     // Send to GA if popover is displayed.
-    if (!popoverBanner.is(':hidden')){
+    if (popoverBanner.is(':visible')) {
         mdn.analytics.trackEvent({
             category: 'Contribution banner',
             action: 'shown',

--- a/kuma/static/js/contribution-handler.js
+++ b/kuma/static/js/contribution-handler.js
@@ -503,11 +503,13 @@
 
     setupTooltips();
 
-    // Send GA Event.
-    mdn.analytics.trackEvent({
-        category: 'Contribution banner',
-        action: 'shown',
-        value: 1
-    });
+    // Send to GA if popover is displayed.
+    if (!popoverBanner.is(':hidden')){
+        mdn.analytics.trackEvent({
+            category: 'Contribution banner',
+            action: 'shown',
+            value: 1
+        });
+    }
 
 })(document, window, jQuery);


### PR DESCRIPTION
The GA event was being sent even though the popover was hidden on mobile. 

This simply checks if the popover is hidden before sending the event.