### PR TITLE
Hotfix/load stripe checkout upon interaction

### DIFF
--- a/kuma/contributions/jinja2/contributions/includes/contribution-form.html
+++ b/kuma/contributions/jinja2/contributions/includes/contribution-form.html
@@ -70,6 +70,9 @@
                         and does not receive your payment details.
                     </p>
                 </div>
+                <ul class="errorlist hidden" id="contribution-error-message">
+                    <li>{{_('There has been an issue, please try again later.')}}</li>
+                </ul>
                 <div class="form-footer">
                     <button type="button" id="stripe_submit">
                         <span class="hide-expand">{{_('Contribute')}} {% include 'includes/icons/arrows/chevron-up.svg' %}</span>

--- a/kuma/static/js/contribution-handler.js
+++ b/kuma/static/js/contribution-handler.js
@@ -432,7 +432,6 @@
      * also disables the submission button
      */
     function toggleScriptError() {
-        formButton.toggleClass('disabled');
         formButton.attr('disabled') ? formButton.removeAttr('disabled') : formButton.attr('disabled', 'true');
         formErrorMessage.toggle();
     }

--- a/kuma/static/js/contribution-handler.js
+++ b/kuma/static/js/contribution-handler.js
@@ -357,18 +357,20 @@
             value: 1
         });
 
-        // On success open Stripe Checkout modal.
-        stripeHandler.open({
-            image: 'https://avatars1.githubusercontent.com/u/7565578?s=280&v=4',
-            name: 'MDN Web Docs',
-            description: 'Contribute to MDN Web Docs',
-            zipCode: true,
-            amount: (selectedAmount * 100),
-            email: $(emailField).val(),
-            closed: function() {
-                form.removeClass('disabled');
-            }
-        });
+        if (stripeHandler !== null) {
+            // On success open Stripe Checkout modal.
+            stripeHandler.open({
+                image: 'https://avatars1.githubusercontent.com/u/7565578?s=280&v=4',
+                name: 'MDN Web Docs',
+                description: 'Contribute to MDN Web Docs',
+                zipCode: true,
+                amount: (selectedAmount * 100),
+                email: $(emailField).val(),
+                closed: function() {
+                    form.removeClass('disabled');
+                }
+            });
+        }
     }
 
     /**
@@ -400,6 +402,10 @@
         }
     }
 
+    /**
+     * Gets and executes stripe's checkout.js script to be used when submitting
+     * also handles errors when getting the resource
+     */
     function getStripeCheckoutScript() {
         $.getScript('https://checkout.stripe.com/checkout.js')
             .done(function() {
@@ -427,6 +433,7 @@
      */
     function toggleScriptError() {
         formButton.toggleClass('disabled');
+        formButton.attr('disabled') ? formButton.removeAttr('disabled') : formButton.attr('disabled', 'true');
         formErrorMessage.toggle();
     }
 

--- a/kuma/static/js/contribution-handler.js
+++ b/kuma/static/js/contribution-handler.js
@@ -401,7 +401,7 @@
     }
 
     function getStripeCheckoutScript() {
-        $.getScript('https://checksout.stripe.com/checkout.js')
+        $.getScript('https://checkout.stripe.com/checkout.js')
             .done(function() {
                 // init stripeCheckout handler.
                 stripeHandler = win.StripeCheckout.configure({


### PR DESCRIPTION
This PR will lazy-load the stripe library one when the modal is open.
We don't need to worry about the /contribute page since checkout.js is loaded there anyway