### PR TITLE
Use absolutify for static paths in the email templates

### DIFF
--- a/kuma/contributions/jinja2/contributions/email/thank_you/email.html
+++ b/kuma/contributions/jinja2/contributions/email/thank_you/email.html
@@ -25,7 +25,7 @@
                               <tbody>
                                 <tr>
                                   <td align="left" style="padding:16px 0px">
-                                    <img src="{{ site }}{{ static('img/mdn-web-docs-email-logo.png') }}" width="219" height="45" alt="Mozilla" style="display:block;border:0">
+                                    <img src="{{ static('img/mdn-web-docs-email-logo.png')|absolutify }}" width="219" height="45" alt="Mozilla" style="display:block;border:0">
                                   </td>
                                 </tr>
                               </tbody>
@@ -111,7 +111,7 @@
                                                           <tr>
                                                             <td align="left" style="font-family:Geneva,Tahoma,Verdana,sans-serif;font-size:14px;line-height:22px;color:#555555;padding-top:16px">
                                                                 {% block trans %}
-                                                                If you didn’t get a chance to, <a href="{{ site }}{{url('contribute')}}#contribute-faqs">read more</a> about why MDN are asking for contributions.
+                                                                If you didn’t get a chance to, <a href="{{url('contribute')|absolutify}}#contribute-faqs">read more</a> about why MDN are asking for contributions.
                                                                 {% endblock %}
                                                             </td>
                                                           </tr>
@@ -167,8 +167,8 @@
                       <tbody>
                         <tr>
                           <td align="center" style="font-family:Geneva,Tahoma,Verdana,sans-serif;font-size:14px;line-height:18px;color:#738597;padding:0 20px 40px">
-                            <a href="{{ site }}" target="_blank">
-                              <img src="{{ site }}{{ static('img/favicon144.png') }}" height="50" width="50" alt="Mozilla" style="display:block;border:0">
+                            <a href="{{ url('home')|absolutify }}" target="_blank">
+                              <img src="{{ static('img/favicon144.png')|absolutify }}" height="50" width="50" alt="Mozilla" style="display:block;border:0">
                             </a>
                             <br>
                             <span>

--- a/kuma/contributions/tasks.py
+++ b/kuma/contributions/tasks.py
@@ -19,7 +19,6 @@ def contribute_thank_you_email(username, user_email):
     message_context = {
         'user_email': user_email,
         'username': username,
-        'site': settings.SITE_URL
     }
 
     # TODO: Remove when we ship translations, get legal approval


### PR DESCRIPTION
This was a fix that was missed from @michal-macioszczyk 
I think using `| absolutify` is a better fix than mine @ https://github.com/mozilla/kuma/commit/014c32af15dad191733a0493f158d4614bdc69a6
