### PR TITLE
bug 1490727: Hide form is user has a subscription

### DIFF
--- a/kuma/payments/jinja2/payments/includes/payments-banner.html
+++ b/kuma/payments/jinja2/payments/includes/payments-banner.html
@@ -71,25 +71,38 @@
                                 </a>
                             </div>
                         {% endif %}
+                        {% if recurring_payment and user.stripe_customer_id and not is_popover %}
+                            <div id="already-sub-error" class="align-center login-prompt">
+                                <p>{{_('You already have a monthly payment set up to MDN.')}}</p>
+                                <p>
+                                    {{_('If you need help regarding this payment, please contact')}}
+                                    <a href="{{'mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL}}">{{settings.CONTRIBUTION_SUPPORT_EMAIL}}</a>
+                                </p>
+                            </div>
+                        {% else %}
+                            {% with form=form, default_payment_url=default_payment_url, is_popover=is_popover, recurring_payment=recurring_payment, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url, recurring_payment_enabled=True %}
+                                {%  include "payments/includes/payments-form.html" %}
+                            {% endwith %}
+                        {% endif %}
 
-                        {% with form=form, default_payment_url=default_payment_url, is_popover=is_popover, recurring_payment=recurring_payment, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url, recurring_payment_enabled=True %}
-                            {%  include "payments/includes/payments-form.html" %}
-                        {% endwith %}
-
-                        {% if not user.is_authenticated %}
-                            {% set github_url = provider_login_url('github', process='login') %}
-                            <div id="login-popover" class="hidden align-center login-prompt">
-                                <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
-                                <a href="{{ github_url }}" id="github_redirect_payment" class="payment-form-button js-login-link" data-service="GitHub" rel="nofollow" data-next="{{ github_next_url }}">
-                                    {{ _('Sign in') }}{% include 'includes/icons/social/github.svg' %}
-                                </a>
+                        {% if user.stripe_customer_id %}
+                            <div id="already-sub-error" class="hidden align-center login-prompt">
+                                <p>{{_('You already have a monthly payment set up to MDN.')}}</p>
+                                <p>
+                                    {{_('If you need help regarding this payment, please contact')}}
+                                    <a href="{{'mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL}}">{{settings.CONTRIBUTION_SUPPORT_EMAIL}}</a>
+                                </p>
                             </div>
                         {% endif %}
+
+                        {% set github_url = provider_login_url('github', process='login') %}
+                        <div id="login-popover" class="hidden align-center login-prompt">
+                            <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
+                            <a href="{{ github_url }}" id="github_redirect_payment" class="payment-form-button js-login-link" data-service="GitHub" rel="nofollow" data-next="{{ github_next_url }}">
+                                {{ _('Sign in') }}{% include 'includes/icons/social/github.svg' %}
+                            </a>
+                        </div>
                     </div>
-                {% else %}
-                    {% with form=form, default_payment_url=default_payment_url, is_popover=is_popover, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url, recurring_payment_enabled=False %}
-                        {%- include "payments/includes/payments-form.html" %}
-                    {% endwith %}
                 {% endif %}
             </div>
         </div>

--- a/kuma/payments/jinja2/payments/includes/payments-banner.html
+++ b/kuma/payments/jinja2/payments/includes/payments-banner.html
@@ -103,6 +103,10 @@
                             </a>
                         </div>
                     </div>
+                {% else %}
+                    {% with form=form, default_payment_url=default_payment_url, is_popover=is_popover, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url, recurring_payment_enabled=False %}
+                    {%- include "payments/includes/payments-form.html" %}
+                    {% endwith %}
                 {% endif %}
             </div>
         </div>

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -75,6 +75,7 @@
     var paymentTypeSwitch = doc.querySelectorAll('input[type=radio][name="payment_selector"]');
     var recurringConfirmationContainer = doc.getElementById('recurring-confirmation-container');
 
+    var alreadySubscribedErrorMessage = doc.getElementById('already-sub-error');
     var selectedAmount = 0;
     var submitted = false;
 
@@ -470,6 +471,11 @@
             });
         });
 
+        if (alreadySubscribedErrorMessage && currrentPaymentForm === 'recurring') {
+            form.get(0).classList.add('hidden');
+            alreadySubscribedErrorMessage.classList.remove('hidden');
+        }
+
         currrentPaymentForm === 'recurring'
             ? triggerRecurringPaymentEvent({
                 action: 'banner expanded',
@@ -515,6 +521,12 @@
         });
 
         $(doc).off('keydown.popoverCloseHandler');
+
+        // Ensure the form is displayed
+        form.get(0).classList.remove('hidden');
+        requestUserLogin ? requestUserLogin.classList.add('hidden') : null;
+        alreadySubscribedErrorMessage ? alreadySubscribedErrorMessage.classList.add('hidden') : null;
+
     }
 
     /**
@@ -642,6 +654,12 @@
             popoverBanner.get(0).classList.add('expanded');
             popoverBanner.get(0).classList.remove('expanded-extend');
 
+            // Ensure subscribed users can pay one-time payments
+            if (alreadySubscribedErrorMessage) {
+                form.get(0).classList.remove('hidden');
+                alreadySubscribedErrorMessage.classList.add('hidden');
+            }
+
         } else if (this.value === 'recurring' && currrentPaymentForm === 'one_time') {
             // Switch to recurring payment form only if we're not on the recurring payment form already.
             currrentPaymentForm = 'recurring';
@@ -660,6 +678,12 @@
             // Visually update the form
             form.get(0).classList.add('recurring-form');
             popoverBanner.get(0).classList.add('expanded-extend');
+
+            // Check us user already has a subscription and show error message
+            if (alreadySubscribedErrorMessage) {
+                form.get(0).classList.add('hidden');
+                alreadySubscribedErrorMessage.classList.remove('hidden');
+            }
         }
 
         // Update the form action


### PR DESCRIPTION
Current problem: 
--------------------
- User attempts recurring payment with an invalid card (expired, wrong digits) and is sent to the error page (https://developer.allizom.org/en-US/payments/error)
- If the same user attempts to make a recurring payment again with a valid card, Stripe remembers the old card. The user is redirected to the error page again.
- So the user must take the step of contacting MDN support so they can remove the old card and allow payment with the new card.

Proposal:
------------------

- ~Solve root cause and prevent Stripe from holding onto old, invalid card details from first attempt. However, this requires a degree of card management which is non-trivial.~
- Provide more specific error pages that provide a more accurate description of the problem and how to solve it and prevent multiple subscriptions.

This PR Blocks users from making multiple subscriptions by preventing them form seeing the form if they have a subscription.
This is one potential solution for:

**In this PR**
- https://trello.com/c/gPej9FQ4/84-precent-users-from-making-multiple-subscriptions

**Notes for QA** 
- [ ] Create an account and subscribe to a recurring payment
- [ ] try to create another recurring payment with that same account
- [ ] you should be blocked with some information on how to contact support.
**screenshots**
![screenshot 2018-11-15 at 12 49 32](https://user-images.githubusercontent.com/11092019/48553948-f4a58880-e8d4-11e8-924b-239754bf1e97.png)
